### PR TITLE
Fix synchronizer is_playing return value

### DIFF
--- a/bindings/C/AUD_Sequence.cpp
+++ b/bindings/C/AUD_Sequence.cpp
@@ -165,6 +165,12 @@ AUD_API void AUD_SequenceEntry_move(AUD_SequenceEntry* entry, double begin, doub
 	(*entry)->move(begin, end, skip);
 }
 
+AUD_API void AUD_SequenceEntry_setConstantRangeAnimationData(AUD_SequenceEntry* entry, AUD_AnimateablePropertyType type, int frame_start, int frame_end, float* data)
+{
+	AnimateableProperty* prop = (*entry)->getAnimProperty(static_cast<AnimateablePropertyType>(type));
+	prop->writeConstantRange(data, frame_start, frame_end);
+}
+
 AUD_API void AUD_SequenceEntry_setAnimationData(AUD_SequenceEntry* entry, AUD_AnimateablePropertyType type, int frame, float* data, char animated)
 {
 	AnimateableProperty* prop = (*entry)->getAnimProperty(static_cast<AnimateablePropertyType>(type));

--- a/bindings/C/AUD_Sequence.h
+++ b/bindings/C/AUD_Sequence.h
@@ -68,6 +68,16 @@ extern AUD_API void AUD_Sequence_remove(AUD_Sound* sequence, AUD_SequenceEntry* 
  * Writes animation data to a sequence.
  * \param sequence The sound scene.
  * \param type The type of animation data.
+ * \param frame_start Start of the frame range.
+ * \param frame_end End of the frame range.
+ * \param data The data to write.
+ */
+AUD_API void AUD_SequenceEntry_setConstantRangeAnimationData(AUD_SequenceEntry* entry, AUD_AnimateablePropertyType type, int frame_start, int frame_end, float* data);
+
+/**
+ * Writes animation data to a sequenced entry.
+ * \param entry The sequenced entry.
+ * \param type The type of animation data.
  * \param frame The frame this data is for.
  * \param data The data to write.
  * \param animated Whether the attribute is animated.

--- a/include/sequence/AnimateableProperty.h
+++ b/include/sequence/AnimateableProperty.h
@@ -113,6 +113,14 @@ public:
 	void write(const float* data, int position, int count);
 
 	/**
+	 * Fills the properties frame range with constant value and marks it animated.
+	 * \param data The new value.
+	 * \param position_start The start position in the animation in frames.
+	 * \param position_end The end position in the animation in frames.
+	 */
+	void writeConstantRange(const float* data, int position_start, int position_end);
+
+	/**
 	 * Reads the properties value.
 	 * \param position The position in the animation in frames.
 	 * \param[out] out Where to write the value to.

--- a/include/sequence/SequenceData.h
+++ b/include/sequence/SequenceData.h
@@ -198,12 +198,13 @@ public:
 	/**
 	 * Adds a new entry to the scene.
 	 * \param sound The sound this entry should play.
+	 * \param sequence_data Reference to sequence_data. Mainly needed to get the FPS of the scene.
 	 * \param begin The start time.
 	 * \param end The end time or a negative value if determined by the sound.
 	 * \param skip How much seconds should be skipped at the beginning.
 	 * \return The entry added.
 	 */
-	std::shared_ptr<SequenceEntry> add(std::shared_ptr<ISound> sound, double begin, double end, double skip);
+	std::shared_ptr<SequenceEntry> add(std::shared_ptr<ISound> sound, std::shared_ptr<SequenceData> sequence_data, double begin, double end, double skip);
 
 	/**
 	 * Removes an entry from the scene.

--- a/include/sequence/SequenceEntry.h
+++ b/include/sequence/SequenceEntry.h
@@ -23,6 +23,7 @@
  */
 
 #include "sequence/AnimateableProperty.h"
+#include "sequence/SequenceData.h"
 #include "util/ILockable.h"
 
 #include <mutex>
@@ -62,6 +63,9 @@ private:
 
 	/// How many seconds are skipped at the beginning.
 	double m_skip;
+
+	/// reference to sequence_data. Mainly needed to get the FPS of the scene.
+	std::shared_ptr<SequenceData> m_sequence_data;
 
 	/// Whether the entry is muted.
 	bool m_muted;
@@ -122,9 +126,10 @@ public:
 	 * \param begin The start time.
 	 * \param end The end time or a negative value if determined by the sound.
 	 * \param skip How much seconds should be skipped at the beginning.
+	 * \param sequence_data Reference to sequence_data. Mainly needed to get the FPS of the scene.
 	 * \param id The ID of the entry.
 	 */
-	SequenceEntry(std::shared_ptr<ISound> sound, double begin, double end, double skip, int id);
+	SequenceEntry(std::shared_ptr<ISound> sound, double begin, double end, double skip, std::shared_ptr<SequenceData> sequence_data, int id);
 	virtual ~SequenceEntry();
 
 	/**

--- a/plugins/coreaudio/CoreAudioSynchronizer.cpp
+++ b/plugins/coreaudio/CoreAudioSynchronizer.cpp
@@ -121,7 +121,7 @@ void CoreAudioSynchronizer::setSyncCallback(ISynchronizer::syncFunction function
 
 int CoreAudioSynchronizer::isPlaying()
 {
-	return m_playing;
+	return m_playing ? 1 : -1;
 }
 
 AUD_NAMESPACE_END

--- a/src/sequence/AnimateableProperty.cpp
+++ b/src/sequence/AnimateableProperty.cpp
@@ -65,6 +65,18 @@ void AnimateableProperty::write(const float* data)
 	std::memcpy(getBuffer(), data, m_count * sizeof(float));
 }
 
+void AnimateableProperty::writeConstantRange(const float* data, int position_start, int position_end)
+{
+	assureSize(position_end * m_count * sizeof(float), true);
+	float* buf = getBuffer();
+
+	for(int i = position_start; i < position_end; i++)
+	{
+		std::memcpy(buf + i * m_count, data, m_count * sizeof(float));
+	}
+	m_isAnimated = true;
+}
+
 void AnimateableProperty::write(const float* data, int position, int count)
 {
 	std::lock_guard<std::recursive_mutex> lock(m_mutex);

--- a/src/sequence/Sequence.cpp
+++ b/src/sequence/Sequence.cpp
@@ -92,7 +92,7 @@ AnimateableProperty* Sequence::getAnimProperty(AnimateablePropertyType type)
 
 std::shared_ptr<SequenceEntry> Sequence::add(std::shared_ptr<ISound> sound, double begin, double end, double skip)
 {
-	return m_sequence->add(sound, begin, end, skip);
+	return m_sequence->add(sound, m_sequence, begin, end, skip);
 }
 
 void Sequence::remove(std::shared_ptr<SequenceEntry> entry)

--- a/src/sequence/SequenceData.cpp
+++ b/src/sequence/SequenceData.cpp
@@ -149,11 +149,11 @@ AnimateableProperty* SequenceData::getAnimProperty(AnimateablePropertyType type)
 	}
 }
 
-std::shared_ptr<SequenceEntry> SequenceData::add(std::shared_ptr<ISound> sound, double begin, double end, double skip)
+std::shared_ptr<SequenceEntry> SequenceData::add(std::shared_ptr<ISound> sound, std::shared_ptr<SequenceData> sequence_data, double begin, double end, double skip)
 {
 	std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
-	std::shared_ptr<SequenceEntry> entry = std::shared_ptr<SequenceEntry>(new SequenceEntry(sound, begin, end, skip, m_id++));
+	std::shared_ptr<SequenceEntry> entry = std::shared_ptr<SequenceEntry>(new SequenceEntry(sound, begin, end, skip, sequence_data, m_id++));
 
 	m_entries.push_back(entry);
 	m_entry_status++;

--- a/src/sequence/SequenceEntry.cpp
+++ b/src/sequence/SequenceEntry.cpp
@@ -22,7 +22,7 @@
 
 AUD_NAMESPACE_BEGIN
 
-SequenceEntry::SequenceEntry(std::shared_ptr<ISound> sound, double begin, double end, double skip, int id) :
+SequenceEntry::SequenceEntry(std::shared_ptr<ISound> sound, double begin, double end, double skip, std::shared_ptr<SequenceData> sequence_data, int id) :
 	m_status(0),
 	m_pos_status(1),
 	m_sound_status(0),
@@ -31,6 +31,7 @@ SequenceEntry::SequenceEntry(std::shared_ptr<ISound> sound, double begin, double
 	m_begin(begin),
 	m_end(end),
 	m_skip(skip),
+	m_sequence_data(sequence_data),
 	m_muted(false),
 	m_relative(true),
 	m_volume_max(1.0f),

--- a/src/sequence/SequenceHandle.cpp
+++ b/src/sequence/SequenceHandle.cpp
@@ -251,7 +251,7 @@ bool SequenceHandle::seek(double position)
 	double target_frame = 0;
 	if(pitch_property != nullptr)
 	{
-		int frame_start = (m_entry->m_begin + m_entry->m_skip) * m_entry->m_sequence_data->getFPS();
+		int frame_start = (m_entry->m_begin - m_entry->m_skip) * m_entry->m_sequence_data->getFPS();
 		int i = 0;
 		while(seek_frame > 0)
 		{

--- a/src/sequence/SequenceHandle.cpp
+++ b/src/sequence/SequenceHandle.cpp
@@ -241,10 +241,35 @@ bool SequenceHandle::seek(double position)
 		return false;
 
 	std::lock_guard<ILockable> lock(*m_entry);
-	double seekpos = position - m_entry->m_begin;
-	if(seekpos < 0)
-		seekpos = 0;
-	seekpos += m_entry->m_skip;
+	double seek_frame = (position - m_entry->m_begin) * m_entry->m_sequence_data->getFPS();
+	if(seek_frame < 0)
+		seek_frame = 0;
+	seek_frame += m_entry->m_skip * m_entry->m_sequence_data->getFPS();
+
+	AnimateableProperty* pitch_property = m_entry->getAnimProperty(AP_PITCH);
+
+	double target_frame = 0;
+	if(pitch_property != nullptr)
+	{
+		int frame_start = (m_entry->m_begin + m_entry->m_skip) * m_entry->m_sequence_data->getFPS();
+		int i = 0;
+		while(seek_frame > 0)
+		{
+			float pitch;
+			pitch_property->read(frame_start + i, &pitch);
+			const double factor = seek_frame > 1.0 ? 1.0 : seek_frame;
+			target_frame += pitch * factor;
+			seek_frame--;
+			i++;
+		}
+	}
+	else
+	{
+		target_frame = seek_frame;
+	}
+
+	double seekpos = target_frame / m_entry->m_sequence_data->getFPS();
+
 	m_handle->setPitch(1.0f);
 	m_handle->seek(seekpos);
 


### PR DESCRIPTION
Fix core audio synchronizer returning value different than default
synchronizer when not playng.

This causes issues in Blender code, see https://projects.blender.org/blender/blender/issues/107726#issuecomment-991514