### PR TITLE
Add ResampleQuality enum and APIs to control resampling quality

### DIFF
--- a/bindings/C/AUD_Sound.cpp
+++ b/bindings/C/AUD_Sound.cpp
@@ -560,7 +560,7 @@ AUD_API AUD_Sound* AUD_Sound_rechannel(AUD_Sound* sound, AUD_Channels channels)
 	}
 }
 
-AUD_API AUD_Sound* AUD_Sound_resample(AUD_Sound* sound, AUD_SampleRate rate, bool high_quality)
+AUD_API AUD_Sound* AUD_Sound_resample(AUD_Sound* sound, AUD_SampleRate rate, AUD_ResampleQuality quality)
 {
 	assert(sound);
 
@@ -570,10 +570,14 @@ AUD_API AUD_Sound* AUD_Sound_resample(AUD_Sound* sound, AUD_SampleRate rate, boo
 		specs.channels = CHANNELS_INVALID;
 		specs.rate = rate;
 		specs.format = FORMAT_INVALID;
-		if(high_quality)
-			return new AUD_Sound(new JOSResample(*sound, specs));
-		else
+		if (quality == AUD_RES_Q_FASTEST)
+		{
 			return new AUD_Sound(new LinearResample(*sound, specs));
+		}
+		else
+		{
+			return new AUD_Sound(new JOSResample(*sound, specs, static_cast<ResampleQuality>(quality)));
+		}
 	}
 	catch(Exception&)
 	{

--- a/bindings/C/AUD_Sound.h
+++ b/bindings/C/AUD_Sound.h
@@ -300,10 +300,10 @@ extern AUD_API AUD_Sound* AUD_Sound_rechannel(AUD_Sound* sound, AUD_Channels cha
  * Resamples the sound.
  * \param sound The sound to resample.
  * \param rate The new sample rate.
- * \param high_quality When true use a higher quality but slower resampler.
+ * \param quality Resampling quality vs performance choice.
  * \return The resampled sound.
  */
-extern AUD_API AUD_Sound* AUD_Sound_resample(AUD_Sound* sound, AUD_SampleRate rate, bool high_quality);
+extern AUD_API AUD_Sound* AUD_Sound_resample(AUD_Sound* sound, AUD_SampleRate rate, AUD_ResampleQuality quality);
 
 /**
  * Reverses a sound. Make sure the sound source can be reversed.

--- a/bindings/C/AUD_Special.cpp
+++ b/bindings/C/AUD_Special.cpp
@@ -351,7 +351,7 @@ AUD_API AUD_Device* AUD_openMixdownDevice(AUD_DeviceSpecs specs, AUD_Sound* sequ
 	try
 	{
 		ReadDevice* device = new ReadDevice(convCToDSpec(specs));
-		device->setQuality(true);
+		device->setQuality(ResampleQuality::HIGH);
 		device->setVolume(volume);
 
 		Sequence* f = dynamic_cast<Sequence*>(sequencer->get());

--- a/bindings/C/AUD_Special.cpp
+++ b/bindings/C/AUD_Special.cpp
@@ -270,14 +270,14 @@ AUD_API int AUD_readSound(AUD_Sound* sound, float* buffer, int length, int sampl
 	return length;
 }
 
-AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, void(*callback)(float, void*), void* data, char* error, size_t errorsize)
+AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality, void(*callback)(float, void*), void* data, char* error, size_t errorsize)
 {
 	try
 	{
 		Sequence* f = dynamic_cast<Sequence *>(sound->get());
 
 		f->setSpecs(convCToSpec(specs.specs));
-		std::shared_ptr<IReader> reader = f->createQualityReader();
+		std::shared_ptr<IReader> reader = f->createQualityReader(static_cast<ResampleQuality>(quality));
 		reader->seek(start);
 		std::shared_ptr<IWriter> writer = FileWriter::createWriter(filename, convCToDSpec(specs), static_cast<Container>(format), static_cast<Codec>(codec), bitrate);
 		FileWriter::writeReader(reader, writer, length, buffersize, callback, data);
@@ -295,7 +295,7 @@ AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned int lengt
 	}
 }
 
-AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, void(*callback)(float, void*), void* data, char* error, size_t errorsize)
+AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality, void(*callback)(float, void*), void* data, char* error, size_t errorsize)
 {
 	try
 	{
@@ -329,7 +329,7 @@ AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start, unsign
 			writers.push_back(FileWriter::createWriter(stream.str(), convCToDSpec(specs), static_cast<Container>(format), static_cast<Codec>(codec), bitrate));
 		}
 
-		std::shared_ptr<IReader> reader = f->createQualityReader();
+		std::shared_ptr<IReader> reader = f->createQualityReader(static_cast<ResampleQuality>(quality));
 		reader->seek(start);
 		FileWriter::writeReader(reader, writers, length, buffersize, callback, data);
 
@@ -346,7 +346,7 @@ AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start, unsign
 	}
 }
 
-AUD_API AUD_Device* AUD_openMixdownDevice(AUD_DeviceSpecs specs, AUD_Sound* sequencer, float volume, double start)
+AUD_API AUD_Device* AUD_openMixdownDevice(AUD_DeviceSpecs specs, AUD_Sound* sequencer, float volume, AUD_ResampleQuality quality, double start)
 {
 	try
 	{
@@ -358,7 +358,7 @@ AUD_API AUD_Device* AUD_openMixdownDevice(AUD_DeviceSpecs specs, AUD_Sound* sequ
 
 		f->setSpecs(convCToSpec(specs.specs));
 
-		AUD_Handle handle = device->play(f->createQualityReader());
+		AUD_Handle handle = device->play(f->createQualityReader(static_cast<ResampleQuality>(quality)));
 		if(handle.get())
 		{
 			handle->seek(start);

--- a/bindings/C/AUD_Special.h
+++ b/bindings/C/AUD_Special.h
@@ -69,6 +69,7 @@ extern AUD_API int AUD_readSound(AUD_Sound* sound, float* buffer, int length, in
  * \param format The file's container format.
  * \param codec The codec used for encoding the audio data.
  * \param bitrate The bitrate for encoding.
+ * \param quality The resampling quality.
  * \param callback A callback function that is called periodically during mixdown, reporting progress if length > 0. Can be NULL.
  * \param data Pass through parameter that is passed to the callback.
  * \param error String buffer to copy the error message to in case of failure.
@@ -78,7 +79,7 @@ extern AUD_API int AUD_readSound(AUD_Sound* sound, float* buffer, int length, in
 extern AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned int length,
 							   unsigned int buffersize, const char* filename,
 							   AUD_DeviceSpecs specs, AUD_Container format,
-							   AUD_Codec codec, unsigned int bitrate,
+							   AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality,
 							   void(*callback)(float, void*), void* data, char* error, size_t errorsize);
 
 /**
@@ -92,6 +93,7 @@ extern AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned in
  * \param format The file's container format.
  * \param codec The codec used for encoding the audio data.
  * \param bitrate The bitrate for encoding.
+ * \param quality The resampling quality.
  * \param callback A callback function that is called periodically during mixdown, reporting progress if length > 0. Can be NULL.
  * \param data Pass through parameter that is passed to the callback.
  * \param error String buffer to copy the error message to in case of failure.
@@ -101,7 +103,7 @@ extern AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned in
 extern AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start, unsigned int length,
 										   unsigned int buffersize, const char* filename,
 										   AUD_DeviceSpecs specs, AUD_Container format,
-										   AUD_Codec codec, unsigned int bitrate,
+										   AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality,
 										   void(*callback)(float, void*), void* data, char* error, size_t errorsize);
 
 /**
@@ -109,10 +111,12 @@ extern AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start,
  * \param specs Output audio specifications.
  * \param sequencer The sound scene to mix down.
  * \param volume The overall mixdown volume.
+ * \param quality The resampling quality.
  * \param start The start time of the mixdown in the sound scene.
  * \return The read device for the mixdown.
  */
-extern AUD_API AUD_Device* AUD_openMixdownDevice(AUD_DeviceSpecs specs, AUD_Sound* sequencer, float volume, double start);
+extern AUD_API AUD_Device* AUD_openMixdownDevice(AUD_DeviceSpecs specs, AUD_Sound* sequencer,
+												 float volume, AUD_ResampleQuality quality, double start);
 
 /**
  * Initializes audio routines (FFMPEG/JACK if it is enabled).

--- a/bindings/C/AUD_Types.h
+++ b/bindings/C/AUD_Types.h
@@ -119,6 +119,15 @@ typedef enum
 	AUD_CHANNELS_SURROUND71 = 8	/// 7.1 surround sound.
 } AUD_Channels;
 
+/// Resampling algorithm and quality.
+typedef enum
+{
+	AUD_RES_Q_FASTEST = 0, /// Linear resample, very fast but lowest quality.
+	AUD_RES_Q_LOW     = 1, /// JOS resample at low quality preset.
+	AUD_RES_Q_MEDIUM  = 2, /// JOS resample at medium quality preset.
+	AUD_RES_Q_HIGH    = 3  /// JOS resample at high quality preset.
+} AUD_ResampleQuality;
+
 /**
  * The sample rate tells how many samples are played back within one second.
  * Some exotic formats may use other sample rates than provided here.

--- a/bindings/python/PySound.cpp
+++ b/bindings/python/PySound.cpp
@@ -1308,7 +1308,7 @@ Sound_resample(Sound* self, PyObject* args)
 			specs.rate = rate;
 			specs.format = FORMAT_INVALID;
 			if(high_quality)
-				parent->sound = new std::shared_ptr<ISound>(new JOSResample(*reinterpret_cast<std::shared_ptr<ISound>*>(self->sound), specs));
+				parent->sound = new std::shared_ptr<ISound>(new JOSResample(*reinterpret_cast<std::shared_ptr<ISound>*>(self->sound), specs, ResampleQuality::HIGH));
 			else
 				parent->sound = new std::shared_ptr<ISound>(new LinearResample(*reinterpret_cast<std::shared_ptr<ISound>*>(self->sound), specs));
 		}

--- a/bindings/python/PySound.cpp
+++ b/bindings/python/PySound.cpp
@@ -1269,12 +1269,12 @@ Sound_rechannel(Sound* self, PyObject* args)
 }
 
 PyDoc_STRVAR(M_aud_Sound_resample_doc,
-			 ".. method:: resample(rate, high_quality)\n\n"
+			 ".. method:: resample(rate, quality)\n\n"
 			 "   Resamples the sound.\n\n"
 			 "   :arg rate: The new sample rate.\n"
 			 "   :type rate: double\n"
-			 "   :arg high_quality: When true use a higher quality but slower resampler.\n"
-			 "   :type high_quality: bool\n"
+			 "   :arg quality: Resampler performance vs quality choice (0=fastest, 3=slowest).\n"
+			 "   :type quality: int\n"
 			 "   :return: The created :class:`Sound` object.\n"
 			 "   :rtype: :class:`Sound`");
 
@@ -1282,19 +1282,10 @@ static PyObject *
 Sound_resample(Sound* self, PyObject* args)
 {
 	double rate;
-	PyObject* high_qualityo;
-	bool high_quality = false;
+	int quality = 0;
 
-	if(!PyArg_ParseTuple(args, "d|O:resample", &rate, &high_qualityo))
+	if(!PyArg_ParseTuple(args, "d|i:resample", &rate, &quality))
 		return nullptr;
-
-	if(!PyBool_Check(high_qualityo))
-	{
-		PyErr_SetString(PyExc_TypeError, "high_quality is not a boolean!");
-		return nullptr;
-	}
-
-	high_quality = high_qualityo == Py_True;
 
 	PyTypeObject* type = Py_TYPE(self);
 	Sound* parent = (Sound*)type->tp_alloc(type, 0);
@@ -1307,10 +1298,10 @@ Sound_resample(Sound* self, PyObject* args)
 			specs.channels = CHANNELS_INVALID;
 			specs.rate = rate;
 			specs.format = FORMAT_INVALID;
-			if(high_quality)
-				parent->sound = new std::shared_ptr<ISound>(new JOSResample(*reinterpret_cast<std::shared_ptr<ISound>*>(self->sound), specs, ResampleQuality::HIGH));
-			else
+			if (quality == int(ResampleQuality::FASTEST))
 				parent->sound = new std::shared_ptr<ISound>(new LinearResample(*reinterpret_cast<std::shared_ptr<ISound>*>(self->sound), specs));
+			else
+				parent->sound = new std::shared_ptr<ISound>(new JOSResample(*reinterpret_cast<std::shared_ptr<ISound>*>(self->sound), specs, static_cast<ResampleQuality>(quality)));
 		}
 		catch(Exception& e)
 		{

--- a/include/devices/SoftwareDevice.h
+++ b/include/devices/SoftwareDevice.h
@@ -231,9 +231,9 @@ protected:
 	std::shared_ptr<Mixer> m_mixer;
 
 	/**
-	 * Whether to do high or low quality resampling.
+	 * Resampling quality.
 	 */
-	bool m_quality;
+	ResampleQuality m_quality;
 
 	/**
 	 * Initializes member variables.
@@ -347,9 +347,9 @@ public:
 
 	/**
 	 * Sets the resampling quality.
-	 * \param quality Low (false) or high (true) quality.
+	 * \param quality Resampling quality vs performance setting.
 	 */
-	void setQuality(bool quality);
+	void setQuality(ResampleQuality quality);
 
 	virtual DeviceSpecs getSpecs() const;
 	virtual std::shared_ptr<IHandle> play(std::shared_ptr<IReader> reader, bool keep = false);

--- a/include/respec/JOSResample.h
+++ b/include/respec/JOSResample.h
@@ -36,13 +36,15 @@ private:
 	JOSResample(const JOSResample&) = delete;
 	JOSResample& operator=(const JOSResample&) = delete;
 
+	ResampleQuality m_quality;
+
 public:
 	/**
 	 * Creates a new sound.
 	 * \param sound The input sound.
 	 * \param specs The target specifications.
 	 */
-	JOSResample(std::shared_ptr<ISound> sound, DeviceSpecs specs);
+	JOSResample(std::shared_ptr<ISound> sound, DeviceSpecs specs, ResampleQuality quality);
 
 	virtual std::shared_ptr<IReader> createReader();
 };

--- a/include/respec/JOSResampleReader.h
+++ b/include/respec/JOSResampleReader.h
@@ -36,39 +36,39 @@ private:
 	typedef void (JOSResampleReader::*resample_f)(double target_factor, int length, sample_t* buffer);
 
 	/**
-	 * The half filter length for Quality::HIGH setting. 
+	 * The half filter length for HIGH quality setting. 
 	 */
 	static const int m_len_high;
 	/**
-	 * The half filter length for Quality::MEDIUM setting.
+	 * The half filter length for MEDIUM quality setting.
 	 */
 	static const int m_len_medium;
 	/**
-	 * The half filter length for Quality::LOW setting.
+	 * The half filter length for LOW quality setting.
 	 */
 	static const int m_len_low;
 	/**
-	 * The filter sample step size for Quality::HIGH setting.
+	 * The filter sample step size for HIGH quality setting.
 	 */
 	static const int m_L_high;
 	/**
-	 * The filter sample step size for Quality::MEDIUM setting.
+	 * The filter sample step size for MEDIUM quality setting.
 	 */
 	static const int m_L_medium;
 	/**
-	 * The filter sample step size for Quality::LOW setting.
+	 * The filter sample step size for LOW quality setting.
 	 */
 	static const int m_L_low;
 	/**
-	 * The filter coefficients for Quality::HIGH setting.
+	 * The filter coefficients for HIGH quality setting.
 	 */
 	static const float m_coeff_high[];
 	/**
-	 * The filter coefficients for Quality::MEDIUM setting.
+	 * The filter coefficients for MEDIUM quality setting.
 	 */
 	static const float m_coeff_medium[];
 	/**
-	 * The filter coefficients for Quality::LOW setting.
+	 * The filter coefficients for LOW quality setting.
 	 */
 	static const float m_coeff_low[];
 
@@ -152,19 +152,13 @@ private:
 	void AUD_LOCAL resample(double target_factor, int length, sample_t* buffer);
 
 public:
-	enum class Quality
-	{
-		LOW = 0,
-		MEDIUM,
-		HIGH,
-	};
 
 	/**
 	 * Creates a resampling reader.
 	 * \param reader The reader to mix.
 	 * \param rate The target sampling rate.
 	 */
-	JOSResampleReader(std::shared_ptr<IReader> reader, SampleRate rate, Quality = Quality::HIGH);
+	JOSResampleReader(std::shared_ptr<IReader> reader, SampleRate rate, ResampleQuality = ResampleQuality::HIGH);
 
 	virtual void seek(int position);
 	virtual int getLength() const;

--- a/include/respec/Specification.h
+++ b/include/respec/Specification.h
@@ -83,6 +83,15 @@ enum Channel
 	CHANNEL_MAX
 };
 
+/// Resampling algorithm and quality.
+enum class ResampleQuality
+{
+	FASTEST = 0, /// Linear resample, very fast but lowest quality.
+	LOW,         /// JOS resample at low quality preset.
+	MEDIUM,      /// JOS resample at medium quality preset.
+	HIGH         /// JOS resample at high quality preset.
+};
+
 /**
  * The sample rate tells how many samples are played back within one second.
  * Some exotic formats may use other sample rates than provided here.

--- a/include/sequence/Sequence.h
+++ b/include/sequence/Sequence.h
@@ -160,10 +160,11 @@ public:
 	void remove(std::shared_ptr<SequenceEntry> entry);
 
 	/**
-	 * Creates a new reader with high quality resampling.
+	 * Creates a new reader with indicated resampling quality.
+	 * \param quality The resampling quality.
 	 * \return The new reader.
 	 */
-	std::shared_ptr<IReader> createQualityReader();
+	std::shared_ptr<IReader> createQualityReader(ResampleQuality quality);
 
 	virtual std::shared_ptr<IReader> createReader();
 };

--- a/include/sequence/SequenceReader.h
+++ b/include/sequence/SequenceReader.h
@@ -74,9 +74,9 @@ public:
 	/**
 	 * Creates a resampling reader.
 	 * \param sequence The sequence data.
-	 * \param quality Whether a high quality resample should be used for resampling.
+	 * \param quality Resampling quality vs performance option.
 	 */
-	SequenceReader(std::shared_ptr<SequenceData> sequence, bool quality = false);
+	SequenceReader(std::shared_ptr<SequenceData> sequence, ResampleQuality quality = ResampleQuality::FASTEST);
 
 	/**
 	 * Destroys the reader.

--- a/src/devices/SoftwareDevice.cpp
+++ b/src/devices/SoftwareDevice.cpp
@@ -718,7 +718,7 @@ void SoftwareDevice::create()
 	m_doppler_factor = 1.0f;
 	m_distance_model = DISTANCE_MODEL_INVERSE_CLAMPED;
 	m_flags = 0;
-	m_quality = false;
+	m_quality = ResampleQuality::FASTEST;
 }
 
 void SoftwareDevice::destroy()
@@ -829,7 +829,7 @@ void SoftwareDevice::setPanning(IHandle* handle, float pan)
 	h->m_user_pan = pan;
 }
 
-void SoftwareDevice::setQuality(bool quality)
+void SoftwareDevice::setQuality(ResampleQuality quality)
 {
 	m_quality = quality;
 }
@@ -886,10 +886,14 @@ std::shared_ptr<IHandle> SoftwareDevice::play(std::shared_ptr<IReader> reader, b
 	std::shared_ptr<ResampleReader> resampler;
 
 	// resample
-	if(m_quality)
-		resampler = std::shared_ptr<ResampleReader>(new JOSResampleReader(reader, m_specs.rate));
-	else
+	if (m_quality == ResampleQuality::FASTEST)
+	{
 		resampler = std::shared_ptr<ResampleReader>(new LinearResampleReader(reader, m_specs.rate));
+	}
+	else
+	{
+		resampler = std::shared_ptr<ResampleReader>(new JOSResampleReader(reader, m_specs.rate, m_quality));
+	}
 	reader = std::shared_ptr<IReader>(resampler);
 
 	// rechannel

--- a/src/respec/JOSResample.cpp
+++ b/src/respec/JOSResample.cpp
@@ -19,15 +19,14 @@
 
 AUD_NAMESPACE_BEGIN
 
-JOSResample::JOSResample(std::shared_ptr<ISound> sound,
-													 DeviceSpecs specs) :
-		SpecsChanger(sound, specs)
+JOSResample::JOSResample(std::shared_ptr<ISound> sound, DeviceSpecs specs, ResampleQuality quality) :
+		SpecsChanger(sound, specs), m_quality(quality)
 {
 }
 
 std::shared_ptr<IReader> JOSResample::createReader()
 {
-	return std::shared_ptr<IReader>(new JOSResampleReader(getReader(), m_specs.rate));
+	return std::shared_ptr<IReader>(new JOSResampleReader(getReader(), m_specs.rate, m_quality));
 }
 
 AUD_NAMESPACE_END

--- a/src/respec/JOSResampleReader.cpp
+++ b/src/respec/JOSResampleReader.cpp
@@ -45,7 +45,7 @@ static inline int lrint_impl(double x)
 
 AUD_NAMESPACE_BEGIN
 
-JOSResampleReader::JOSResampleReader(std::shared_ptr<IReader> reader, SampleRate rate, Quality quality) :
+JOSResampleReader::JOSResampleReader(std::shared_ptr<IReader> reader, SampleRate rate, ResampleQuality quality) :
 	ResampleReader(reader, rate),
 	m_channels(CHANNELS_INVALID),
 	m_n(0),
@@ -55,17 +55,17 @@ JOSResampleReader::JOSResampleReader(std::shared_ptr<IReader> reader, SampleRate
 {
 	switch(quality)
 	{
-	case Quality::LOW:
+	case ResampleQuality::LOW:
 		m_len = m_len_low;
 		m_L = m_L_low;
 		m_coeff = m_coeff_low;
 		break;
-	case Quality::MEDIUM:
+	case ResampleQuality::MEDIUM:
 		m_len = m_len_medium;
 		m_L = m_L_medium;
 		m_coeff = m_coeff_medium;
 		break;
-	case Quality::HIGH:
+	case ResampleQuality::HIGH:
 		m_len = m_len_high;
 		m_L = m_L_high;
 		m_coeff = m_coeff_high;

--- a/src/sequence/Sequence.cpp
+++ b/src/sequence/Sequence.cpp
@@ -102,7 +102,7 @@ void Sequence::remove(std::shared_ptr<SequenceEntry> entry)
 
 std::shared_ptr<IReader> Sequence::createQualityReader()
 {
-	return std::shared_ptr<IReader>(new SequenceReader(m_sequence, true));
+	return std::shared_ptr<IReader>(new SequenceReader(m_sequence, ResampleQuality::HIGH));
 }
 
 std::shared_ptr<IReader> Sequence::createReader()

--- a/src/sequence/Sequence.cpp
+++ b/src/sequence/Sequence.cpp
@@ -100,9 +100,9 @@ void Sequence::remove(std::shared_ptr<SequenceEntry> entry)
 	m_sequence->remove(entry);
 }
 
-std::shared_ptr<IReader> Sequence::createQualityReader()
+std::shared_ptr<IReader> Sequence::createQualityReader(ResampleQuality quality)
 {
-	return std::shared_ptr<IReader>(new SequenceReader(m_sequence, ResampleQuality::HIGH));
+	return std::shared_ptr<IReader>(new SequenceReader(m_sequence, quality));
 }
 
 std::shared_ptr<IReader> Sequence::createReader()

--- a/src/sequence/SequenceReader.cpp
+++ b/src/sequence/SequenceReader.cpp
@@ -25,7 +25,7 @@
 
 AUD_NAMESPACE_BEGIN
 
-SequenceReader::SequenceReader(std::shared_ptr<SequenceData> sequence, bool quality) :
+SequenceReader::SequenceReader(std::shared_ptr<SequenceData> sequence, ResampleQuality quality) :
 	m_position(0), m_device(sequence->m_specs), m_sequence(sequence), m_status(0), m_entry_status(0)
 {
 	m_device.setQuality(quality);


### PR DESCRIPTION
Previous PR (#18) added quality levels to JOS resampler, but there was no API to actually pick them, except by changing the actual library code.

This adds ResampleQuality enum to public API, as well as usage of it:
- SoftwareDevice::setQuality uses that instead of bool,
- JOSResample constructor got ResampleQuality argument,
- SequenceReader constructor uses that instead of bool,
- A corresponding AUD_ResampleQuality in the C API, and AUD_Sound_resample uses that instead of bool.

Places that are still left "hardcoded" to high quality JOS resampler:
- Python Sound_resample still uses bool high_quality argument, that picks HIGH JOS quality.
- AUD_openMixdownDevice uses HIGH JOS quality.
- Sequence::createQualityReader uses HIGH JOS quality.