### PR TITLE
Avoid std::string copies by value

### DIFF
--- a/include/Exception.h
+++ b/include/Exception.h
@@ -69,7 +69,7 @@ protected:
 	 * @param file The source code file in which the exception was thrown.
 	 * @param line The source code line from which the exception was thrown.
 	 */
-	Exception(std::string message, std::string file, int line);
+	Exception(const std::string &message, const std::string &file, int line);
 public:
 	/**
 	 * Destroys the object.
@@ -120,7 +120,7 @@ public:
 	 * @param file The source code file in which the exception was thrown.
 	 * @param line The source code line from which the exception was thrown.
 	 */
-	FileException(std::string message, std::string file, int line);
+	FileException(const std::string &message, const std::string &file, int line);
 
 	/**
 	 * Copy constructor.
@@ -145,7 +145,7 @@ public:
 	 * @param file The source code file in which the exception was thrown.
 	 * @param line The source code line from which the exception was thrown.
 	 */
-	DeviceException(std::string message, std::string file, int line);
+	DeviceException(const std::string &message, const std::string &file, int line);
 
 	/**
 	 * Copy constructor.
@@ -171,7 +171,7 @@ public:
 	 * @param file The source code file in which the exception was thrown.
 	 * @param line The source code line from which the exception was thrown.
 	 */
-	StateException(std::string message, std::string file, int line);
+	StateException(const std::string &message, const std::string &file, int line);
 
 	/**
 	 * Copy constructor.

--- a/include/devices/DeviceManager.h
+++ b/include/devices/DeviceManager.h
@@ -62,14 +62,14 @@ public:
 	 * @param name A representative name for the device.
 	 * @param factory The factory that creates the device.
 	 */
-	static void registerDevice(std::string name, std::shared_ptr<IDeviceFactory> factory);
+	static void registerDevice(const std::string &name, std::shared_ptr<IDeviceFactory> factory);
 
 	/**
 	 * Returns the factory for a specific device.
 	 * @param name The representative name of the device.
 	 * @return The factory if it was found, or nullptr otherwise.
 	 */
-	static std::shared_ptr<IDeviceFactory> getDeviceFactory(std::string name);
+	static std::shared_ptr<IDeviceFactory> getDeviceFactory(const std::string &name);
 
 	/**
 	 * Returns the default device based on the priorities of the registered factories.
@@ -92,7 +92,7 @@ public:
 	 * If a device is currently being handled it will be released.
 	 * @param name The representative name of the device.
 	 */
-	static void openDevice(std::string name);
+	static void openDevice(const std::string &name);
 
 	/**
 	 * Opens the default device which will then be handled by the manager.

--- a/include/devices/IDeviceFactory.h
+++ b/include/devices/IDeviceFactory.h
@@ -71,7 +71,7 @@ public:
 	 * Sets a name for the device.
 	 * \param name The internal name for the device.
 	 */
-	virtual void setName(std::string name)=0;
+	virtual void setName(const std::string &name)=0;
 };
 
 AUD_NAMESPACE_END

--- a/include/file/File.h
+++ b/include/file/File.h
@@ -69,7 +69,7 @@ public:
 	 * \param filename The sound file path.
 	 * \param stream The index of the audio stream within the file if it contains multiple audio streams.
 	 */
-	File(std::string filename, int stream = 0);
+	File(const std::string &filename, int stream = 0);
 
 	/**
 	 * Creates a new sound.

--- a/include/file/FileManager.h
+++ b/include/file/FileManager.h
@@ -72,7 +72,7 @@ public:
 	 * @return The reader created.
 	 * @exception Exception If no file input can read the file an exception is thrown.
 	 */
-	static std::shared_ptr<IReader> createReader(std::string filename, int stream = 0);
+	static std::shared_ptr<IReader> createReader(const std::string &filename, int stream = 0);
 
 	/**
 	 * Creates a file reader for the given buffer if a registed IFileInput is able to read it.
@@ -89,7 +89,7 @@ public:
 	 * \return A vector with as many streams as there are in the file.
 	 * \exception Exception Thrown if the file specified cannot be read.
 	 */
-	static std::vector<StreamInfo> queryStreams(std::string filename);
+	static std::vector<StreamInfo> queryStreams(const std::string &filename);
 
 	/**
 	 * Queries the streams of a sound file.
@@ -110,7 +110,7 @@ public:
 	 * @return A writer that creates the file.
 	 * @exception Exception If no file output can write the file with the given specification an exception is thrown.
 	 */
-	static std::shared_ptr<IWriter> createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
+	static std::shared_ptr<IWriter> createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
 };
 
 AUD_NAMESPACE_END

--- a/include/file/FileWriter.h
+++ b/include/file/FileWriter.h
@@ -54,7 +54,7 @@ public:
 	 * \param bitrate The bitrate for encoding.
 	 * \return The writer to write data to.
 	 */
-	static std::shared_ptr<IWriter> createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
+	static std::shared_ptr<IWriter> createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
 
 	/**
 	 * Writes a reader to a writer.

--- a/include/file/IFileInput.h
+++ b/include/file/IFileInput.h
@@ -54,7 +54,7 @@ public:
 	 * \return The reader that reads the file.
 	 * \exception Exception Thrown if the file specified cannot be read.
 	 */
-	virtual std::shared_ptr<IReader> createReader(std::string filename, int stream = 0)=0;
+	virtual std::shared_ptr<IReader> createReader(const std::string &filename, int stream = 0)=0;
 
 	/**
 	 * Creates a reader for a file to be read from memory.
@@ -71,7 +71,7 @@ public:
 	 * \return A vector with as many streams as there are in the file.
 	 * \exception Exception Thrown if the file specified cannot be read.
 	 */
-	virtual std::vector<StreamInfo> queryStreams(std::string filename)=0;
+	virtual std::vector<StreamInfo> queryStreams(const std::string &filename)=0;
 
 	/**
 	 * Queries the streams of a sound file.

--- a/include/file/IFileOutput.h
+++ b/include/file/IFileOutput.h
@@ -46,7 +46,7 @@ public:
 	 * \param bitrate The bitrate for encoding.
 	 * \exception Exception Thrown if the file specified cannot be written.
 	 */
-	virtual std::shared_ptr<IWriter> createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)=0;
+	virtual std::shared_ptr<IWriter> createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)=0;
 };
 
 AUD_NAMESPACE_END

--- a/plugins/coreaudio/CoreAudioDevice.cpp
+++ b/plugins/coreaudio/CoreAudioDevice.cpp
@@ -210,7 +210,7 @@ public:
 		m_buffersize = buffersize;
 	}
 
-	virtual void setName(std::string name)
+	virtual void setName(const std::string &name)
 	{
 	}
 };

--- a/plugins/ffmpeg/FFMPEG.cpp
+++ b/plugins/ffmpeg/FFMPEG.cpp
@@ -35,7 +35,7 @@ void FFMPEG::registerPlugin()
 	FileManager::registerOutput(plugin);
 }
 
-std::shared_ptr<IReader> FFMPEG::createReader(std::string filename, int stream)
+std::shared_ptr<IReader> FFMPEG::createReader(const std::string &filename, int stream)
 {
 	return std::shared_ptr<IReader>(new FFMPEGReader(filename, stream));
 }
@@ -45,7 +45,7 @@ std::shared_ptr<IReader> FFMPEG::createReader(std::shared_ptr<Buffer> buffer, in
 	return std::shared_ptr<IReader>(new FFMPEGReader(buffer, stream));
 }
 
-std::vector<StreamInfo> FFMPEG::queryStreams(std::string filename)
+std::vector<StreamInfo> FFMPEG::queryStreams(const std::string &filename)
 {
 	return FFMPEGReader(filename).queryStreams();
 }
@@ -55,7 +55,7 @@ std::vector<StreamInfo> FFMPEG::queryStreams(std::shared_ptr<Buffer> buffer)
 	return FFMPEGReader(buffer).queryStreams();
 }
 
-std::shared_ptr<IWriter> FFMPEG::createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
+std::shared_ptr<IWriter> FFMPEG::createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
 {
 	return std::shared_ptr<IWriter>(new FFMPEGWriter(filename, specs, format, codec, bitrate));
 }

--- a/plugins/ffmpeg/FFMPEG.h
+++ b/plugins/ffmpeg/FFMPEG.h
@@ -52,11 +52,11 @@ public:
 	 */
 	static void registerPlugin();
 
-	virtual std::shared_ptr<IReader> createReader(std::string filename, int stream = 0);
+	virtual std::shared_ptr<IReader> createReader(const std::string &filename, int stream = 0);
 	virtual std::shared_ptr<IReader> createReader(std::shared_ptr<Buffer> buffer, int stream = 0);
-	virtual std::vector<StreamInfo> queryStreams(std::string filename);
+	virtual std::vector<StreamInfo> queryStreams(const std::string &filename);
 	virtual std::vector<StreamInfo> queryStreams(std::shared_ptr<Buffer> buffer);
-	virtual std::shared_ptr<IWriter> createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
+	virtual std::shared_ptr<IWriter> createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
 };
 
 AUD_NAMESPACE_END

--- a/plugins/ffmpeg/FFMPEGReader.cpp
+++ b/plugins/ffmpeg/FFMPEGReader.cpp
@@ -239,7 +239,7 @@ void FFMPEGReader::init(int stream)
 	m_specs.rate = (SampleRate) m_codecCtx->sample_rate;
 }
 
-FFMPEGReader::FFMPEGReader(std::string filename, int stream) :
+FFMPEGReader::FFMPEGReader(const std::string &filename, int stream) :
 	m_pkgbuf(),
 	m_formatCtx(nullptr),
 	m_codecCtx(nullptr),

--- a/plugins/ffmpeg/FFMPEGReader.h
+++ b/plugins/ffmpeg/FFMPEGReader.h
@@ -154,7 +154,7 @@ public:
 	 * \exception Exception Thrown if the file specified does not exist or
 	 *            cannot be read with ffmpeg.
 	 */
-	FFMPEGReader(std::string filename, int stream = 0);
+	FFMPEGReader(const std::string &filename, int stream = 0);
 
 	/**
 	 * Creates a new reader.

--- a/plugins/ffmpeg/FFMPEGWriter.cpp
+++ b/plugins/ffmpeg/FFMPEGWriter.cpp
@@ -158,7 +158,7 @@ void FFMPEGWriter::close()
 #endif
 }
 
-FFMPEGWriter::FFMPEGWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate) :
+FFMPEGWriter::FFMPEGWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate) :
 	m_position(0),
 	m_specs(specs),
 	m_formatCtx(nullptr),

--- a/plugins/ffmpeg/FFMPEGWriter.h
+++ b/plugins/ffmpeg/FFMPEGWriter.h
@@ -135,7 +135,7 @@ public:
 	 * \exception Exception Thrown if the file specified does not exist or
 	 *            cannot be read with ffmpeg.
 	 */
-	FFMPEGWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
+	FFMPEGWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
 
 	/**
 	 * Destroys the writer and closes the file.

--- a/plugins/jack/JackDevice.cpp
+++ b/plugins/jack/JackDevice.cpp
@@ -162,7 +162,7 @@ void JackDevice::jack_shutdown(void* data)
 	device->m_valid = false;
 }
 
-JackDevice::JackDevice(std::string name, DeviceSpecs specs, int buffersize) :
+JackDevice::JackDevice(const std::string &name, DeviceSpecs specs, int buffersize) :
 	m_synchronizer(this)
 {
 	if(specs.channels == CHANNELS_INVALID)
@@ -358,7 +358,7 @@ public:
 		m_buffersize = buffersize;
 	}
 
-	virtual void setName(std::string name)
+	virtual void setName(const std::string &name)
 	{
 		m_name = name;
 	}

--- a/plugins/jack/JackDevice.h
+++ b/plugins/jack/JackDevice.h
@@ -151,7 +151,7 @@ public:
 	 * \param buffersize The size of the internal buffer.
 	 * \exception Exception Thrown if the audio device cannot be opened.
 	 */
-	JackDevice(std::string name, DeviceSpecs specs, int buffersize = AUD_DEFAULT_BUFFER_SIZE);
+	JackDevice(const std::string &name, DeviceSpecs specs, int buffersize = AUD_DEFAULT_BUFFER_SIZE);
 
 	/**
 	 * Closes the JACK client.

--- a/plugins/libsndfile/SndFile.cpp
+++ b/plugins/libsndfile/SndFile.cpp
@@ -32,7 +32,7 @@ void SndFile::registerPlugin()
 	FileManager::registerOutput(plugin);
 }
 
-std::shared_ptr<IReader> SndFile::createReader(std::string filename, int stream)
+std::shared_ptr<IReader> SndFile::createReader(const std::string &filename, int stream)
 {
 	return std::shared_ptr<IReader>(new SndFileReader(filename));
 }
@@ -42,7 +42,7 @@ std::shared_ptr<IReader> SndFile::createReader(std::shared_ptr<Buffer> buffer, i
 	return std::shared_ptr<IReader>(new SndFileReader(buffer));
 }
 
-std::vector<StreamInfo> SndFile::queryStreams(std::string filename)
+std::vector<StreamInfo> SndFile::queryStreams(const std::string &filename)
 {
 	return SndFileReader(filename).queryStreams();
 }
@@ -52,7 +52,7 @@ std::vector<StreamInfo> SndFile::queryStreams(std::shared_ptr<Buffer> buffer)
 	return SndFileReader(buffer).queryStreams();
 }
 
-std::shared_ptr<IWriter> SndFile::createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
+std::shared_ptr<IWriter> SndFile::createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
 {
 	return std::shared_ptr<IWriter>(new SndFileWriter(filename, specs, format, codec, bitrate));
 }

--- a/plugins/libsndfile/SndFile.h
+++ b/plugins/libsndfile/SndFile.h
@@ -52,11 +52,11 @@ public:
 	 */
 	static void registerPlugin();
 
-	virtual std::shared_ptr<IReader> createReader(std::string filename, int stream = 0);
+	virtual std::shared_ptr<IReader> createReader(const std::string &filename, int stream = 0);
 	virtual std::shared_ptr<IReader> createReader(std::shared_ptr<Buffer> buffer, int stream = 0);
-	virtual std::vector<StreamInfo> queryStreams(std::string filename);
+	virtual std::vector<StreamInfo> queryStreams(const std::string &filename);
 	virtual std::vector<StreamInfo> queryStreams(std::shared_ptr<Buffer> buffer);
-	virtual std::shared_ptr<IWriter> createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
+	virtual std::shared_ptr<IWriter> createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
 };
 
 AUD_NAMESPACE_END

--- a/plugins/libsndfile/SndFileReader.cpp
+++ b/plugins/libsndfile/SndFileReader.cpp
@@ -71,7 +71,7 @@ sf_count_t SndFileReader::vio_tell(void* user_data)
 	return reader->m_memoffset;
 }
 
-SndFileReader::SndFileReader(std::string filename) :
+SndFileReader::SndFileReader(const std::string &filename) :
 	m_position(0)
 {
 	SF_INFO sfinfo;

--- a/plugins/libsndfile/SndFileReader.h
+++ b/plugins/libsndfile/SndFileReader.h
@@ -103,7 +103,7 @@ public:
 	 * \exception Exception Thrown if the file specified does not exist or
 	 *            cannot be read with libsndfile.
 	 */
-	SndFileReader(std::string filename);
+	SndFileReader(const std::string &filename);
 
 	/**
 	 * Creates a new reader.

--- a/plugins/libsndfile/SndFileWriter.cpp
+++ b/plugins/libsndfile/SndFileWriter.cpp
@@ -21,7 +21,7 @@
 
 AUD_NAMESPACE_BEGIN
 
-SndFileWriter::SndFileWriter(std::string filename, DeviceSpecs specs,
+SndFileWriter::SndFileWriter(const std::string &filename, DeviceSpecs specs,
 									 Container format, Codec codec, unsigned int bitrate) :
 	m_position(0), m_specs(specs)
 {

--- a/plugins/libsndfile/SndFileWriter.h
+++ b/plugins/libsndfile/SndFileWriter.h
@@ -69,7 +69,7 @@ public:
 	 * \exception Exception Thrown if the file specified cannot be written
 	 *                          with libsndfile.
 	 */
-	SndFileWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
+	SndFileWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate);
 
 	/**
 	 * Destroys the writer and closes the file.

--- a/plugins/openal/OpenALDevice.cpp
+++ b/plugins/openal/OpenALDevice.cpp
@@ -1131,7 +1131,7 @@ void OpenALDevice::updateStreams()
 /**************************** IDevice Code ************************************/
 /******************************************************************************/
 
-OpenALDevice::OpenALDevice(DeviceSpecs specs, int buffersize, std::string name) :
+OpenALDevice::OpenALDevice(DeviceSpecs specs, int buffersize, const std::string &name) :
 	m_name(name), m_playing(false), m_buffersize(buffersize)
 {
 	// cannot determine how many channels or which format OpenAL uses, but
@@ -1561,7 +1561,7 @@ private:
 	std::string m_name;
 
 public:
-	OpenALDeviceFactory(std::string name = "") :
+	OpenALDeviceFactory(const std::string &name = "") :
 		m_buffersize(AUD_DEFAULT_BUFFER_SIZE),
 		m_name(name)
 	{
@@ -1590,7 +1590,7 @@ public:
 		m_buffersize = buffersize;
 	}
 
-	virtual void setName(std::string name)
+	virtual void setName(const std::string &name)
 	{
 	}
 };
@@ -1599,7 +1599,7 @@ void OpenALDevice::registerPlugin()
 {
 	auto names = OpenALDevice::getDeviceNames();
 	DeviceManager::registerDevice("OpenAL", std::shared_ptr<IDeviceFactory>(new OpenALDeviceFactory));
-	for(std::string &name : names)
+	for(const std::string &name : names)
 	{
 		DeviceManager::registerDevice("OpenAL - " + name, std::shared_ptr<IDeviceFactory>(new OpenALDeviceFactory(name)));
 	}

--- a/plugins/openal/OpenALDevice.h
+++ b/plugins/openal/OpenALDevice.h
@@ -269,7 +269,7 @@ public:
 	 * \note The buffersize will be multiplicated by three for this device.
 	 * \exception DeviceException Thrown if the audio device cannot be opened.
 	 */
-	OpenALDevice(DeviceSpecs specs, int buffersize = AUD_DEFAULT_BUFFER_SIZE, std::string name = "");
+	OpenALDevice(DeviceSpecs specs, int buffersize = AUD_DEFAULT_BUFFER_SIZE, const std::string &name = "");
 
 	virtual ~OpenALDevice();
 

--- a/plugins/pulseaudio/PulseAudioDevice.cpp
+++ b/plugins/pulseaudio/PulseAudioDevice.cpp
@@ -121,7 +121,7 @@ void PulseAudioDevice::playing(bool playing)
 	AUD_pa_threaded_mainloop_unlock(m_mainloop);
 }
 
-PulseAudioDevice::PulseAudioDevice(std::string name, DeviceSpecs specs, int buffersize) :
+PulseAudioDevice::PulseAudioDevice(const std::string &name, DeviceSpecs specs, int buffersize) :
 	m_synchronizer(this),
 	m_playback(false),
 	m_state(PA_CONTEXT_UNCONNECTED),
@@ -321,7 +321,7 @@ public:
 		m_buffersize = buffersize;
 	}
 
-	virtual void setName(std::string name)
+	virtual void setName(const std::string &name)
 	{
 		m_name = name;
 	}

--- a/plugins/pulseaudio/PulseAudioDevice.h
+++ b/plugins/pulseaudio/PulseAudioDevice.h
@@ -128,7 +128,7 @@ public:
 	 * \note The specification really used for opening the device may differ.
 	 * \exception Exception Thrown if the audio device cannot be opened.
 	 */
-	PulseAudioDevice(std::string name, DeviceSpecs specs, int buffersize = AUD_DEFAULT_BUFFER_SIZE);
+	PulseAudioDevice(const std::string &name, DeviceSpecs specs, int buffersize = AUD_DEFAULT_BUFFER_SIZE);
 
 	/**
 	 * Closes the PulseAudio audio device.

--- a/plugins/sdl/SDLDevice.cpp
+++ b/plugins/sdl/SDLDevice.cpp
@@ -157,7 +157,7 @@ public:
 		m_buffersize = buffersize;
 	}
 
-	virtual void setName(std::string name)
+	virtual void setName(const std::string &name)
 	{
 	}
 };

--- a/plugins/wasapi/WASAPIDevice.cpp
+++ b/plugins/wasapi/WASAPIDevice.cpp
@@ -458,7 +458,7 @@ public:
 		m_buffersize = buffersize;
 	}
 
-	virtual void setName(std::string name)
+	virtual void setName(const std::string &name)
 	{
 	}
 };

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -25,7 +25,7 @@ Exception::Exception(const Exception& exception) :
 {
 }
 
-Exception::Exception(std::string message, std::string file, int line) :
+Exception::Exception(const std::string &message, const std::string &file, int line) :
 	m_message(message),
 	m_file(file),
 	m_line(line)
@@ -65,7 +65,7 @@ int Exception::getLine() const
 	return m_line;
 }
 
-FileException::FileException(std::string message, std::string file, int line) :
+FileException::FileException(const std::string &message, const std::string &file, int line) :
 	Exception(message, file, line)
 {
 }
@@ -79,7 +79,7 @@ FileException::~FileException() AUD_NOEXCEPT
 {
 }
 
-DeviceException::DeviceException(std::string message, std::string file, int line) :
+DeviceException::DeviceException(const std::string &message, const std::string &file, int line) :
 	Exception(message, file, line)
 {
 }
@@ -93,7 +93,7 @@ DeviceException::~DeviceException() AUD_NOEXCEPT
 {
 }
 
-StateException::StateException(std::string message, std::string file, int line) :
+StateException::StateException(const std::string &message, const std::string &file, int line) :
 	Exception(message, file, line)
 {
 }

--- a/src/devices/DeviceManager.cpp
+++ b/src/devices/DeviceManager.cpp
@@ -28,12 +28,12 @@ AUD_NAMESPACE_BEGIN
 std::unordered_map<std::string, std::shared_ptr<IDeviceFactory>> DeviceManager::m_factories;
 std::shared_ptr<IDevice> DeviceManager::m_device;
 
-void DeviceManager::registerDevice(std::string name, std::shared_ptr<IDeviceFactory> factory)
+void DeviceManager::registerDevice(const std::string &name, std::shared_ptr<IDeviceFactory> factory)
 {
 	m_factories[name] = factory;
 }
 
-std::shared_ptr<IDeviceFactory> DeviceManager::getDeviceFactory(std::string name)
+std::shared_ptr<IDeviceFactory> DeviceManager::getDeviceFactory(const std::string &name)
 {
 	auto it = m_factories.find(name);
 
@@ -66,7 +66,7 @@ void DeviceManager::setDevice(std::shared_ptr<IDevice> device)
 	m_device = device;
 }
 
-void DeviceManager::openDevice(std::string name)
+void DeviceManager::openDevice(const std::string &name)
 {
 	setDevice(getDeviceFactory(name)->openDevice());
 }

--- a/src/devices/NULLDevice.cpp
+++ b/src/devices/NULLDevice.cpp
@@ -180,7 +180,7 @@ public:
 	{
 	}
 
-	virtual void setName(std::string name)
+	virtual void setName(const std::string &name)
 	{
 	}
 };

--- a/src/file/File.cpp
+++ b/src/file/File.cpp
@@ -23,7 +23,7 @@
 
 AUD_NAMESPACE_BEGIN
 
-File::File(std::string filename, int stream) :
+File::File(const std::string &filename, int stream) :
 	m_filename(filename), m_stream(stream)
 {
 }

--- a/src/file/FileManager.cpp
+++ b/src/file/FileManager.cpp
@@ -43,7 +43,7 @@ void FileManager::registerOutput(std::shared_ptr<aud::IFileOutput> output)
 	outputs().push_back(output);
 }
 
-std::shared_ptr<IReader> FileManager::createReader(std::string filename, int stream)
+std::shared_ptr<IReader> FileManager::createReader(const std::string &filename, int stream)
 {
 	for(std::shared_ptr<IFileInput> input : inputs())
 	{
@@ -71,7 +71,7 @@ std::shared_ptr<IReader> FileManager::createReader(std::shared_ptr<Buffer> buffe
 	AUD_THROW(FileException, "The file couldn't be read with any installed file reader.");
 }
 
-std::vector<StreamInfo> FileManager::queryStreams(std::string filename)
+std::vector<StreamInfo> FileManager::queryStreams(const std::string &filename)
 {
 	for(std::shared_ptr<IFileInput> input : inputs())
 	{
@@ -99,7 +99,7 @@ std::vector<StreamInfo> FileManager::queryStreams(std::shared_ptr<Buffer> buffer
 	AUD_THROW(FileException, "The file couldn't be read with any installed file reader.");
 }
 
-std::shared_ptr<IWriter> FileManager::createWriter(std::string filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
+std::shared_ptr<IWriter> FileManager::createWriter(const std::string &filename, DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
 {
 	for(std::shared_ptr<IFileOutput> output : outputs())
 	{

--- a/src/file/FileWriter.cpp
+++ b/src/file/FileWriter.cpp
@@ -22,7 +22,7 @@
 
 AUD_NAMESPACE_BEGIN
 
-std::shared_ptr<IWriter> FileWriter::createWriter(std::string filename,DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
+std::shared_ptr<IWriter> FileWriter::createWriter(const std::string &filename,DeviceSpecs specs, Container format, Codec codec, unsigned int bitrate)
 {
 	return FileManager::createWriter(filename, specs, format, codec, bitrate);
 }


### PR DESCRIPTION
Many places in the API were taking std::string arguments by copy (which means memory allocation etc.) instead of by const reference, without seemingly a good reason.