### PR TITLE
Fix abnormal termination on exit after playback on MacOS

### DIFF
--- a/include/devices/OpenCloseDevice.h
+++ b/include/devices/OpenCloseDevice.h
@@ -33,82 +33,84 @@ AUD_NAMESPACE_BEGIN
 /**
  * This device extends the SoftwareDevice with code for running mixing in a separate thread.
  */
-class AUD_PLUGIN_API OpenCloseDevice : public SoftwareDevice {
- private:
-  /**
-   * Whether the device is opened.
-   */
-  bool m_device_opened{false};
+class AUD_PLUGIN_API OpenCloseDevice : public SoftwareDevice
+{
+private:
+	/**
+	 * Whether the device is opened.
+	 */
+	bool m_device_opened{false};
 
-  /**
-   * Whether there is currently playback.
-   */
-  bool m_playing{false};
+	/**
+	 * Whether there is currently playback.
+	 */
+	bool m_playing{false};
 
-  /**
-   * Whether thread released the device.
-   */
-  bool m_delayed_close_finished{false};
+	/**
+	 * Whether thread released the device.
+	 */
+	bool m_delayed_close_finished{false};
 
-  /**
-   * Thread condition to terminate immediately. Used when class is destroyed.
-   */
-  std::condition_variable stop_condition;
+	/**
+	 * Thread condition to terminate immediately. Used when class is destroyed.
+	 */
+	std::condition_variable stop_condition;
 
-  /**
-   * Mutex for `stop_condition`.
-   */
-  std::mutex stop_condition_mutex;
+	/**
+	 * Mutex for `stop_condition`.
+	 */
 
-  /**
-   * Thread used to release the device after time delay.
-   */
-  std::thread m_delayed_close_thread;
+	std::mutex stop_condition_mutex;
 
-  /**
-   * How long to wait until closing the device..
-   */
-  std::chrono::milliseconds m_device_close_delay{std::chrono::milliseconds(10000)};
+	/**
+	 * Thread used to release the device after time delay.
+	 */
+	std::thread m_delayed_close_thread;
 
-  /**
-   * Time when playback has stopped.
-   */
-  std::chrono::time_point<std::chrono::steady_clock> m_playback_stopped_time;
+	/**
+	 * How long to wait until closing the device..
+	 */
+	std::chrono::milliseconds m_device_close_delay{std::chrono::milliseconds(10000)};
 
-  /**
-   * Releases the device after time delay.
-   */
-  void closeAfterDelay();
+	/**
+	 * Time when playback has stopped.
+	 */
+	std::chrono::time_point<std::chrono::steady_clock> m_playback_stopped_time;
 
-  /**
-   * Starts the playback.
-   */
-  AUD_LOCAL virtual void start() = 0;
+	/**
+	 * Releases the device after time delay.
+	 */
+	void closeAfterDelay();
 
-  /**
-   * Stops the playbsck.
-   */
-  AUD_LOCAL virtual void stop() = 0;
+	/**
+	 * Starts the playback.
+	 */
+	AUD_LOCAL virtual void start() = 0;
 
-  /**
-   * Acquires the device.
-   */
-  AUD_LOCAL virtual void open() = 0;
+	/**
+	 * Stops the playbsck.
+	 */
+	AUD_LOCAL virtual void stop() = 0;
 
-  /**
-   * Releases the device.
-   */
-  AUD_LOCAL virtual void close() = 0;
+	/**
+	 * Acquires the device.
+	 */
+	AUD_LOCAL virtual void open() = 0;
 
-  // delete copy constructor and operator=
-  OpenCloseDevice(const OpenCloseDevice &) = delete;
-  OpenCloseDevice &operator=(const OpenCloseDevice &) = delete;
+	/**
+	 * Releases the device.
+	 */
+	AUD_LOCAL virtual void close() = 0;
 
- protected:
-  OpenCloseDevice() = default;
-  ~OpenCloseDevice();
+	// delete copy constructor and operator=
+	OpenCloseDevice(const OpenCloseDevice&) = delete;
+	OpenCloseDevice& operator=(const OpenCloseDevice&) = delete;
 
-  virtual void playing(bool playing);
+protected:
+	OpenCloseDevice() = default;
+	~OpenCloseDevice();
+
+	virtual void playing(bool playing);
 };
 
 AUD_NAMESPACE_END

--- a/include/devices/OpenCloseDevice.h
+++ b/include/devices/OpenCloseDevice.h
@@ -51,6 +51,11 @@ private:
 	bool m_delayed_close_finished{false};
 
 	/**
+	 * Terminate thread without closing devide. Used when class is destroyed.
+	*/
+	bool m_join_immediately{false};
+
+	/**
 	 * Thread used to release the device after time delay.
 	 */
 	std::thread m_delayed_close_thread;
@@ -96,6 +101,7 @@ private:
 
 protected:
 	OpenCloseDevice() = default;
+	~OpenCloseDevice();
 
 	virtual void playing(bool playing);
 };

--- a/src/devices/OpenCloseDevice.cpp
+++ b/src/devices/OpenCloseDevice.cpp
@@ -21,58 +21,57 @@ AUD_NAMESPACE_BEGIN
 
 void OpenCloseDevice::closeAfterDelay()
 {
-	for(;;)
-	{
-		std::this_thread::sleep_for(m_device_close_delay / 10);
-		if(m_playing || m_playback_stopped_time.time_since_epoch().count() == 0)
-			m_playback_stopped_time = std::chrono::steady_clock::now();
-		if(!m_join_immediately && std::chrono::steady_clock::now() < m_playback_stopped_time + m_device_close_delay)
-			continue;
+  for (;;) {
+    std::unique_lock<std::mutex> lock(stop_condition_mutex);
+    if (stop_condition.wait_until(lock,
+                                  std::chrono::steady_clock::now() + m_device_close_delay / 10) !=
+        std::cv_status::timeout)
+    {
+      return;
+    }
+    if (m_playing || m_playback_stopped_time.time_since_epoch().count() == 0)
+      m_playback_stopped_time = std::chrono::steady_clock::now();
+    if (std::chrono::steady_clock::now() < m_playback_stopped_time + m_device_close_delay) {
+      continue;
+    }
 
-		break;
-	}
+    break;
+  }
 
-	if(!m_join_immediately)
-		close();
-
-	m_delayed_close_finished = true;
-	m_device_opened = false;
+  close();
+  m_delayed_close_finished = true;
+  m_device_opened = false;
 }
 
 void OpenCloseDevice::playing(bool playing)
 {
-	if(m_playing != playing)
-	{
-		m_playing = playing;
-		if(playing)
-		{
-			if(!m_device_opened)
-				open();
-			m_device_opened = true;
-			start();
-		}
-		else
-		{
-			stop();
-			m_playback_stopped_time = std::chrono::steady_clock::now();
-			if(m_delayed_close_thread.joinable() && m_delayed_close_finished)
-			{
-				m_delayed_close_thread.join();
-				m_delayed_close_finished = false;
-			}
+  if (m_playing != playing) {
+    m_playing = playing;
+    if (playing) {
+      if (!m_device_opened)
+        open();
+      m_device_opened = true;
+      start();
+    }
+    else {
+      stop();
+      m_playback_stopped_time = std::chrono::steady_clock::now();
+      if (m_delayed_close_thread.joinable() && m_delayed_close_finished) {
+        m_delayed_close_thread.join();
+        m_delayed_close_finished = false;
+      }
 
-			if(m_device_opened && !m_delayed_close_thread.joinable())
-				m_delayed_close_thread = std::thread(&OpenCloseDevice::closeAfterDelay, this);
-		}
-	}
+      if (m_device_opened && !m_delayed_close_thread.joinable())
+        m_delayed_close_thread = std::thread(&OpenCloseDevice::closeAfterDelay, this);
+    }
+  }
 }
 
 OpenCloseDevice::~OpenCloseDevice()
 {
-	if(m_delayed_close_thread.joinable())
-	{
-		m_join_immediately = true;
-		m_delayed_close_thread.join();
-	}
+  if (m_delayed_close_thread.joinable()) {
+    stop_condition.notify_one();
+    m_delayed_close_thread.join();
+  }
 }
 AUD_NAMESPACE_END

--- a/src/devices/OpenCloseDevice.cpp
+++ b/src/devices/OpenCloseDevice.cpp
@@ -26,13 +26,13 @@ void OpenCloseDevice::closeAfterDelay()
 		std::this_thread::sleep_for(m_device_close_delay / 10);
 		if(m_playing || m_playback_stopped_time.time_since_epoch().count() == 0)
 			m_playback_stopped_time = std::chrono::steady_clock::now();
-		if(!m_join_immediatelly && std::chrono::steady_clock::now() < m_playback_stopped_time + m_device_close_delay)
+		if(!m_join_immediately && std::chrono::steady_clock::now() < m_playback_stopped_time + m_device_close_delay)
 			continue;
 
 		break;
 	}
 
-	if(!m_join_immediatelly)
+	if(!m_join_immediately)
 		close();
 
 	m_delayed_close_finished = true;


### PR DESCRIPTION
Caused by thread being joinable when class was destroyed.
    
Join thread in destructor without trying to close the audio device,
since this is done in it's destructor.

Reported in Blender tracker: https://projects.blender.org/blender/blender/issues/121015